### PR TITLE
Remove osmosis-cosmwasm coins conversion

### DIFF
--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.1"
 base64 = "0.13.0"
 cosmrs = {version = "0.9.0", features = ["cosmwasm", "rpc"]}
 cosmwasm-std = "1.1.2"
-osmosis-std = {version = "0.13.2"}
 prost = "0.11.0"
 serde = "1.0.144"
 serde_json = "1.0.85"

--- a/packages/test-tube/src/lib.rs
+++ b/packages/test-tube/src/lib.rs
@@ -8,7 +8,6 @@ pub mod runner;
 pub mod utils;
 
 pub use cosmrs;
-pub use osmosis_std;
 
 pub use account::{Account, NonSigningAccount, SigningAccount};
 pub use module::*;

--- a/packages/test-tube/src/utils.rs
+++ b/packages/test-tube/src/utils.rs
@@ -5,7 +5,7 @@ use cosmrs::proto::{
         MsgUpdateAdmin,
     },
 };
-use cosmwasm_std::{BankMsg, Coin, StdResult, WasmMsg};
+use cosmwasm_std::{BankMsg, Coin, WasmMsg};
 use prost::Message;
 
 use crate::{Account, EncodeError, RunnerError, SigningAccount};
@@ -29,27 +29,8 @@ pub fn proto_coin_to_coin(proto_coin: &cosmrs::proto::cosmos::base::v1beta1::Coi
     }
 }
 
-pub fn osmosis_proto_coin_to_coin(
-    proto_coin: &osmosis_std::types::cosmos::base::v1beta1::Coin,
-) -> Coin {
-    Coin {
-        denom: proto_coin.denom.clone(),
-        amount: proto_coin.amount.parse().unwrap(),
-    }
-}
-
 pub fn proto_coins_to_coins(coins: &[cosmrs::proto::cosmos::base::v1beta1::Coin]) -> Vec<Coin> {
     coins.iter().map(proto_coin_to_coin).collect()
-}
-
-pub fn osmosis_coins_to_coins(
-    coins: &[osmosis_std::types::cosmos::base::v1beta1::Coin],
-) -> Vec<Coin> {
-    coins
-        .iter()
-        .map(|c| c.clone().try_into())
-        .collect::<StdResult<_>>()
-        .unwrap()
 }
 
 pub fn msg_to_any<T: Message>(type_url: &str, msg: &T) -> Result<cosmrs::Any, RunnerError> {


### PR DESCRIPTION
Removing these utils so that `test-tube` does not depend on `osmosis-std`

`osmosis-std` have these removed functionality implemented in [this PR](https://github.com/osmosis-labs/osmosis-rust/pull/78)