### PR TITLE
Made initial timestamp fixed.

### DIFF
--- a/packages/osmosis-test-tube/libosmosistesttube/main.go
+++ b/packages/osmosis-test-tube/libosmosistesttube/main.go
@@ -42,11 +42,6 @@ var (
 	mu          sync.Mutex
 )
 
-// Timestamp found in cosmwasm::std::testing::mock_env used so that tests can
-// always use the same timestamp
-const MOCK_ENV_SECONDS = 1_571_797_419
-const MOCK_ENV_NANOS = 879_305_533
-
 //export InitTestEnv
 func InitTestEnv() uint64 {
 	// Temp fix for concurrency issue
@@ -62,7 +57,7 @@ func InitTestEnv() uint64 {
 	// Allow testing unoptimized contract
 	wasmtypes.MaxWasmSize = 1024 * 1024 * 1024 * 1024 * 1024
 
-	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Unix(MOCK_ENV_SECONDS, MOCK_ENV_NANOS).UTC()})
+	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Now().UTC()})
 
 	env.BeginNewBlock(false, 5)
 

--- a/packages/osmosis-test-tube/libosmosistesttube/main.go
+++ b/packages/osmosis-test-tube/libosmosistesttube/main.go
@@ -57,7 +57,7 @@ func InitTestEnv() uint64 {
 	// Allow testing unoptimized contract
 	wasmtypes.MaxWasmSize = 1024 * 1024 * 1024 * 1024 * 1024
 
-	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Now().UTC()})
+	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Unix(1_571_797_419, 879_305_533).UTC()})
 
 	env.BeginNewBlock(false, 5)
 
@@ -180,6 +180,12 @@ func Query(envId uint64, path, base64QueryMsgBytes string) *C.char {
 func GetBlockTime(envId uint64) int64 {
 	env := loadEnv(envId)
 	return env.Ctx.BlockTime().UnixNano()
+}
+
+//export GetBlockHeight
+func GetBlockHeight(envId uint64) int64 {
+	env := loadEnv(envId)
+	return env.Ctx.BlockHeight()
 }
 
 //export AccountSequence

--- a/packages/osmosis-test-tube/libosmosistesttube/main.go
+++ b/packages/osmosis-test-tube/libosmosistesttube/main.go
@@ -42,6 +42,11 @@ var (
 	mu          sync.Mutex
 )
 
+// Timestamp found in cosmwasm::std::testing::mock_env used so that tests can
+// always use the same timestamp
+const MOCK_ENV_SECONDS = 1_571_797_419
+const MOCK_ENV_NANOS = 879_305_533
+
 //export InitTestEnv
 func InitTestEnv() uint64 {
 	// Temp fix for concurrency issue
@@ -57,7 +62,7 @@ func InitTestEnv() uint64 {
 	// Allow testing unoptimized contract
 	wasmtypes.MaxWasmSize = 1024 * 1024 * 1024 * 1024 * 1024
 
-	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Unix(1_571_797_419, 879_305_533).UTC()})
+	env.Ctx = env.App.BaseApp.NewContext(false, tmproto.Header{Height: 0, ChainID: "osmosis-1", Time: time.Unix(MOCK_ENV_SECONDS, MOCK_ENV_NANOS).UTC()})
 
 	env.BeginNewBlock(false, 5)
 

--- a/packages/osmosis-test-tube/src/runner/app.rs
+++ b/packages/osmosis-test-tube/src/runner/app.rs
@@ -37,9 +37,19 @@ impl OsmosisTestApp {
         }
     }
 
-    /// Get the current block time
+    /// Get the current block time in nanoseconds
     pub fn get_block_time_nanos(&self) -> i64 {
         self.inner.get_block_time_nanos()
+    }
+
+    /// Get the current block time in seconds
+    pub fn get_block_time_seconds(&self) -> i64 {
+        self.inner.get_block_time_nanos() / 1_000_000_000i64
+    }
+
+    /// Get the current block height
+    pub fn get_block_height(&self) -> i64 {
+        self.inner.get_block_height()
     }
 
     /// Get the first validator address
@@ -161,6 +171,36 @@ mod tests {
         assert!(accounts.get(1).is_some());
         assert!(accounts.get(2).is_some());
         assert!(accounts.get(3).is_none());
+    }
+
+    #[test]
+    fn test_get_and_set_block_timestamp() {
+        let app = OsmosisTestApp::default();
+
+        let block_time_nanos = app.get_block_time_nanos();
+        let block_time_seconds = app.get_block_time_seconds();
+
+        assert_eq!(block_time_nanos, 1_571_797_424_879_305_533i64);
+        assert_eq!(block_time_seconds, 1_571_797_424i64);
+
+        app.increase_time(10u64);
+
+        assert_eq!(
+            app.get_block_time_nanos(),
+            block_time_nanos + 10_000_000_000
+        );
+        assert_eq!(app.get_block_time_seconds(), block_time_seconds + 10);
+    }
+
+    #[test]
+    fn test_get_block_height() {
+        let app = OsmosisTestApp::default();
+
+        assert_eq!(app.get_block_height(), 1i64);
+
+        app.increase_time(10u64);
+
+        assert_eq!(app.get_block_height(), 2i64);
     }
 
     #[test]

--- a/packages/test-tube/src/bindings.rs
+++ b/packages/test-tube/src/bindings.rs
@@ -262,3 +262,6 @@ extern "C" {
 extern "C" {
     pub fn GetBlockTime(envId: GoUint64) -> GoInt64;
 }
+extern "C" {
+    pub fn GetBlockHeight(envId: GoUint64) -> GoInt64;
+}

--- a/packages/test-tube/src/runner/app.rs
+++ b/packages/test-tube/src/runner/app.rs
@@ -9,8 +9,9 @@ use prost::Message;
 
 use crate::account::{Account, FeeSetting, SigningAccount};
 use crate::bindings::{
-    AccountNumber, AccountSequence, BeginBlock, EndBlock, Execute, GetBlockTime, GetParamSet,
-    GetValidatorAddress, IncreaseTime, InitAccount, InitTestEnv, Query, SetParamSet, Simulate,
+    AccountNumber, AccountSequence, BeginBlock, EndBlock, Execute, GetBlockHeight, GetBlockTime,
+    GetParamSet, GetValidatorAddress, IncreaseTime, InitAccount, InitTestEnv, Query, SetParamSet,
+    Simulate,
 };
 use crate::redefine_as_go_string;
 use crate::runner::error::{DecodeError, EncodeError, RunnerError};
@@ -71,6 +72,10 @@ impl BaseApp {
         unsafe { GetBlockTime(self.id) }
     }
 
+    /// Get the current block height
+    pub fn get_block_height(&self) -> i64 {
+        unsafe { GetBlockHeight(self.id) }
+    }
     /// Initialize account with initial balance of any coins.
     /// This function mints new coins and send to newly created account
     pub fn init_account(&self, coins: &[Coin]) -> RunnerResult<SigningAccount> {


### PR DESCRIPTION
**description:**

In this PR I made the initial timestamp static, fixing it as in `cosmwasm_std::testing::mock_env`.

**rationale:**

This is more useful for myself as it allows me to more easily test some parameters and calculation that depend on block timestamps. I hope it is also helpful for others.

**questions:**

Are there any additional features required to complete issue #4? Please let me know if so and if I am capable I will happily include them in this PR.

