### PR TITLE
Add warning for arm users

### DIFF
--- a/packages/osmosis-test-tube/README.md
+++ b/packages/osmosis-test-tube/README.md
@@ -4,6 +4,8 @@
 
 CosmWasm x Osmosis integration testing library that, unlike `cw-multi-test`, it allows you to test your cosmwasm contract against real chain's logic instead of mocks.
 
+> `osmosis-test-tube` does not work on ARM architectures since it is backed by [`osmosisd`](https://docs.osmosis.zone/osmosis-core/osmosisd/).
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)


### PR DESCRIPTION
Adds a warning to the `osmosis-test-tube` readme for ARM users.

closes #28 