### PR TITLE
feat: Use types from osmosis-std fork

### DIFF
--- a/packages/osmosis-test-tube/Cargo.toml
+++ b/packages/osmosis-test-tube/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["osmosis", "test_artifacts"]
 base64 = "0.13.0"
 cosmrs = { version = "0.9.0", features = ["cosmwasm"] }
 cosmwasm-std = "1.1.2"
-osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", branch = "main" }
+osmosis-std = "0.16.0"
 prost = "0.11.0"
 serde = "1.0.144"
 serde_json = "1.0.85"

--- a/packages/osmosis-test-tube/src/module/bank.rs
+++ b/packages/osmosis-test-tube/src/module/bank.rs
@@ -1,4 +1,4 @@
-use cosmrs::proto::cosmos::bank::v1beta1::{
+use osmosis_std::types::cosmos::bank::v1beta1::{
     MsgSend, MsgSendResponse, QueryAllBalancesRequest, QueryAllBalancesResponse,
     QueryBalanceRequest, QueryBalanceResponse, QueryTotalSupplyRequest, QueryTotalSupplyResponse,
 };

--- a/packages/osmosis-test-tube/src/module/concentrated_liquidity.rs
+++ b/packages/osmosis-test-tube/src/module/concentrated_liquidity.rs
@@ -1,11 +1,14 @@
+use osmosis_std::types::osmosis::concentratedliquidity::poolmodel::concentrated::v1beta1::{
+    MsgCreateConcentratedPool, MsgCreateConcentratedPoolResponse,
+};
 use osmosis_std::types::osmosis::concentratedliquidity::v1beta1::{
     ClaimableSpreadRewardsRequest, ClaimableSpreadRewardsResponse, LiquidityNetInDirectionRequest,
     LiquidityNetInDirectionResponse, LiquidityPerTickRangeRequest, LiquidityPerTickRangeResponse,
     MsgCollectIncentives, MsgCollectIncentivesResponse, MsgCollectSpreadRewards,
-    MsgCollectSpreadRewardsResponse, MsgCreateConcentratedPool, MsgCreateConcentratedPoolResponse,
-    MsgCreatePosition, MsgCreatePositionResponse, MsgWithdrawPosition, MsgWithdrawPositionResponse,
-    ParamsRequest, ParamsResponse, PoolsRequest, PoolsResponse, PositionByIdRequest,
-    PositionByIdResponse, UserPositionsRequest, UserPositionsResponse,
+    MsgCollectSpreadRewardsResponse, MsgCreatePosition, MsgCreatePositionResponse,
+    MsgWithdrawPosition, MsgWithdrawPositionResponse, ParamsRequest, ParamsResponse, PoolsRequest,
+    PoolsResponse, PositionByIdRequest, PositionByIdResponse, UserPositionsRequest,
+    UserPositionsResponse,
 };
 use test_tube::{fn_execute, fn_query, Module};
 
@@ -155,6 +158,7 @@ mod tests {
                 }],
             },
             signer.address(),
+            false,
             &signer,
         )
         .unwrap();

--- a/packages/osmosis-test-tube/src/module/gov.rs
+++ b/packages/osmosis-test-tube/src/module/gov.rs
@@ -1,10 +1,10 @@
-use cosmrs::proto::cosmos::base::v1beta1::Coin;
-use cosmrs::proto::cosmos::gov::v1beta1::{
+use cosmrs::tx::MessageExt;
+use osmosis_std::shim::Any;
+use osmosis_std::types::cosmos::base::v1beta1::Coin;
+use osmosis_std::types::cosmos::gov::v1beta1::{
     MsgSubmitProposal, MsgSubmitProposalResponse, MsgVote, MsgVoteResponse, QueryParamsRequest,
     QueryParamsResponse, QueryProposalRequest, QueryProposalResponse, VoteOption,
 };
-use cosmrs::tx::MessageExt;
-use cosmrs::Any;
 use test_tube::{fn_execute, fn_query, Account, RunnerError, RunnerExecuteResult, SigningAccount};
 
 use test_tube::module::Module;
@@ -48,6 +48,7 @@ where
         msg: M,
         initial_deposit: Vec<cosmwasm_std::Coin>,
         proposer: String,
+        is_expedited: bool,
         signer: &SigningAccount,
     ) -> RunnerExecuteResult<MsgSubmitProposalResponse> {
         self.submit_proposal(
@@ -66,6 +67,7 @@ where
                     })
                     .collect(),
                 proposer,
+                is_expedited,
             },
             signer,
         )
@@ -96,6 +98,7 @@ impl<'a> GovWithAppAccess<'a> {
         msg_type_url: String,
         msg: M,
         proposer: String,
+        is_expedited: bool,
         signer: &SigningAccount,
     ) -> RunnerExecuteResult<MsgSubmitProposalResponse> {
         // query deposit params
@@ -119,6 +122,7 @@ impl<'a> GovWithAppAccess<'a> {
                 }),
                 initial_deposit: min_deposit,
                 proposer,
+                is_expedited,
             },
             signer,
         )?;
@@ -209,6 +213,7 @@ mod tests {
                     code_hash: Vec::new(),
                 },
                 proposer.address(),
+                false,
                 &proposer,
             )
             .unwrap();
@@ -247,6 +252,7 @@ mod tests {
                     wasm_byte_code,
                 },
                 proposer.address(),
+                false,
                 &proposer,
             )
             .unwrap();

--- a/packages/osmosis-test-tube/src/module/pool_manager.rs
+++ b/packages/osmosis-test-tube/src/module/pool_manager.rs
@@ -204,6 +204,7 @@ mod tests {
                 }],
             },
             signer.address(),
+            false,
             &signer,
         )
         .unwrap();

--- a/packages/osmosis-test-tube/src/module/tokenfactory.rs
+++ b/packages/osmosis-test-tube/src/module/tokenfactory.rs
@@ -59,8 +59,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use cosmrs::proto::cosmos::bank::v1beta1::QueryBalanceRequest;
     use cosmwasm_std::Coin;
+    use osmosis_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
     use osmosis_std::types::osmosis::tokenfactory::v1beta1::{
         MsgBurn, MsgChangeAdmin, MsgCreateDenom, MsgMint, QueryDenomAuthorityMetadataRequest,
         QueryDenomsFromCreatorRequest,

--- a/packages/osmosis-test-tube/src/module/wasm.rs
+++ b/packages/osmosis-test-tube/src/module/wasm.rs
@@ -1,9 +1,9 @@
-use cosmrs::proto::cosmwasm::wasm::v1::{
+use cosmwasm_std::Coin;
+use osmosis_std::types::cosmwasm::wasm::v1::{
     AccessConfig, MsgExecuteContract, MsgExecuteContractResponse, MsgInstantiateContract,
     MsgInstantiateContractResponse, MsgStoreCode, MsgStoreCodeResponse,
     QuerySmartContractStateRequest, QuerySmartContractStateResponse,
 };
-use cosmwasm_std::Coin;
 use serde::{de::DeserializeOwned, Serialize};
 
 use test_tube::runner::error::{DecodeError, EncodeError, RunnerError};
@@ -65,7 +65,7 @@ where
                 msg: serde_json::to_vec(msg).map_err(EncodeError::JsonEncodeError)?,
                 funds: funds
                     .iter()
-                    .map(|c| cosmrs::proto::cosmos::base::v1beta1::Coin {
+                    .map(|c| osmosis_std::types::cosmos::base::v1beta1::Coin {
                         denom: c.denom.parse().unwrap(),
                         amount: format!("{}", c.amount.u128()),
                     })
@@ -92,7 +92,7 @@ where
                 msg: serde_json::to_vec(msg).map_err(EncodeError::JsonEncodeError)?,
                 funds: funds
                     .iter()
-                    .map(|c| cosmrs::proto::cosmos::base::v1beta1::Coin {
+                    .map(|c| osmosis_std::types::cosmos::base::v1beta1::Coin {
                         denom: c.denom.parse().unwrap(),
                         amount: format!("{}", c.amount.u128()),
                     })

--- a/packages/osmosis-test-tube/src/runner/app.rs
+++ b/packages/osmosis-test-tube/src/runner/app.rs
@@ -3,6 +3,7 @@ use cosmrs::Any;
 use cosmwasm_std::{Coin, Timestamp};
 
 use prost::Message;
+use serde::de::DeserializeOwned;
 use test_tube::account::SigningAccount;
 
 use test_tube::runner::result::{RunnerExecuteResult, RunnerResult};
@@ -126,7 +127,7 @@ impl<'a> Runner<'a> for OsmosisTestApp {
     fn query<Q, R>(&self, path: &str, q: &Q) -> RunnerResult<R>
     where
         Q: ::prost::Message,
-        R: ::prost::Message + Default,
+        R: ::prost::Message + DeserializeOwned + Default,
     {
         self.inner.query(path, q)
     }
@@ -149,9 +150,9 @@ mod tests {
     use prost::Message;
     use std::option::Option::None;
 
-    use cosmrs::proto::cosmos::bank::v1beta1::QueryAllBalancesRequest;
     use cosmrs::Any;
     use cosmwasm_std::{attr, coins, Coin};
+    use osmosis_std::types::cosmos::bank::v1beta1::QueryAllBalancesRequest;
 
     use osmosis_std::types::osmosis::gamm::v1beta1::QueryTotalSharesRequest;
     use osmosis_std::types::osmosis::lockup::{

--- a/packages/osmosis-test-tube/src/runner/mod.rs
+++ b/packages/osmosis-test-tube/src/runner/mod.rs
@@ -7,12 +7,12 @@ mod tests {
     use crate::{Bank, Wasm};
 
     use super::app::OsmosisTestApp;
-    use cosmrs::proto::cosmos::bank::v1beta1::{MsgSendResponse, QueryBalanceRequest};
-    use cosmrs::proto::cosmwasm::wasm::v1::{
-        MsgExecuteContractResponse, MsgInstantiateContractResponse,
-    };
     use cosmwasm_std::{to_binary, BankMsg, Coin, CosmosMsg, Empty, Event, WasmMsg};
     use cw1_whitelist::msg::{ExecuteMsg, InstantiateMsg};
+    use osmosis_std::types::cosmos::bank::v1beta1::{MsgSendResponse, QueryBalanceRequest};
+    use osmosis_std::types::cosmwasm::wasm::v1::{
+        MsgExecuteContractResponse, MsgInstantiateContractResponse,
+    };
     use osmosis_std::types::osmosis::gamm::poolmodels::balancer::v1beta1::{
         MsgCreateBalancerPool, MsgCreateBalancerPoolResponse,
     };
@@ -33,7 +33,7 @@ mod tests {
         id: u64,
     }
 
-    #[derive(::prost::Message)]
+    #[derive(::prost::Message, serde::Deserialize)]
     struct AdhocRandomQueryResponse {
         #[prost(string, tag = "1")]
         msg: String,

--- a/packages/test-tube/Cargo.toml
+++ b/packages/test-tube/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.2"
 base64 = "0.13.0"
 cosmrs = {version = "0.9.0", features = ["cosmwasm", "rpc"]}
 cosmwasm-std = { version = "1.1.2", features = ["stargate"] }
+osmosis-std = "0.16.0"
 prost = "0.11.0"
 serde = "1.0.144"
 serde_json = "1.0.85"

--- a/packages/test-tube/src/runner/mod.rs
+++ b/packages/test-tube/src/runner/mod.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::CosmosMsg;
+use serde::de::DeserializeOwned;
 
 use crate::account::SigningAccount;
 use crate::runner::result::{RunnerExecuteResult, RunnerResult};
@@ -67,5 +68,5 @@ pub trait Runner<'a> {
     fn query<Q, R>(&self, path: &str, query: &Q) -> RunnerResult<R>
     where
         Q: ::prost::Message,
-        R: ::prost::Message + Default;
+        R: ::prost::Message + DeserializeOwned + Default;
 }


### PR DESCRIPTION
This allows us to add `DeserializeOwned` to generic `R` of fn `query` on trait `Runner`, which is very useful for implementing custom runners such as the [`multi-test-runner` in cw-it](https://github.com/apollodao/cw-it/blob/master/src/multi_test/runner.rs#L26).