### PR TITLE
feat: Move bank and wasm modules to test-tube

### DIFF
--- a/packages/osmosis-test-tube/src/module/mod.rs
+++ b/packages/osmosis-test-tube/src/module/mod.rs
@@ -1,13 +1,13 @@
-mod bank;
 mod concentrated_liquidity;
 mod gamm;
 mod gov;
 mod pool_manager;
 mod tokenfactory;
 mod twap;
-mod wasm;
 
 pub use test_tube::macros;
+pub use test_tube::module::bank;
+pub use test_tube::module::wasm;
 pub use test_tube::module::Module;
 
 pub use bank::Bank;

--- a/packages/test-tube/src/module/bank.rs
+++ b/packages/test-tube/src/module/bank.rs
@@ -1,11 +1,11 @@
-use cosmrs::proto::cosmos::bank::v1beta1::{
+use crate::{fn_execute, fn_query};
+use osmosis_std::types::cosmos::bank::v1beta1::{
     MsgSend, MsgSendResponse, QueryAllBalancesRequest, QueryAllBalancesResponse,
     QueryBalanceRequest, QueryBalanceResponse, QueryTotalSupplyRequest, QueryTotalSupplyResponse,
 };
-use test_tube::{fn_execute, fn_query};
 
-use test_tube::module::Module;
-use test_tube::runner::Runner;
+use crate::module::Module;
+use crate::runner::Runner;
 
 pub struct Bank<'a, R: Runner<'a>> {
     runner: &'a R,

--- a/packages/test-tube/src/module/mod.rs
+++ b/packages/test-tube/src/module/mod.rs
@@ -1,5 +1,11 @@
 use crate::runner::Runner;
 
+pub mod bank;
+pub mod wasm;
+
+pub use bank::Bank;
+pub use wasm::Wasm;
+
 #[macro_use]
 pub mod macros;
 

--- a/packages/test-tube/src/module/wasm.rs
+++ b/packages/test-tube/src/module/wasm.rs
@@ -6,9 +6,9 @@ use cosmrs::proto::cosmwasm::wasm::v1::{
 use cosmwasm_std::Coin;
 use serde::{de::DeserializeOwned, Serialize};
 
-use test_tube::runner::error::{DecodeError, EncodeError, RunnerError};
-use test_tube::runner::result::{RunnerExecuteResult, RunnerResult};
-use test_tube::{
+use crate::runner::error::{DecodeError, EncodeError, RunnerError};
+use crate::runner::result::{RunnerExecuteResult, RunnerResult};
+use crate::{
     account::{Account, SigningAccount},
     runner::Runner,
 };


### PR DESCRIPTION
So that not everyone has to depend on `osmosis-test-tube`.