### PR TITLE
fix: Xcode15 upgrade

### DIFF
--- a/packages/osmosis-test-tube/build.rs
+++ b/packages/osmosis-test-tube/build.rs
@@ -102,6 +102,8 @@ fn build_libosmosistesttube(out: PathBuf) {
         .current_dir(manifest_dir.join("libosmosistesttube"))
         .arg("build")
         .arg("-buildmode=c-shared")
+        .arg("-ldflags")
+        .arg("-w")
         .arg("-o")
         .arg(out)
         .arg("main.go")


### PR DESCRIPTION
With the new update to Xcode 15, the current build causes this error on MacOS 
```
  = note: ld: segment '__DWARF' filesize exceeds vmsize in '/<path>/libosmosistesttube.dylib'
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Details: 
- This was described  in https://github.com/golang/go/issues/50506
- A workaround to not generate the DWARF for debug was used ->  https://github.com/Agoric/agoric-sdk/pull/8368

This follows the approach in the walk-around - not sure if we want to keep it the same for other OS. 