### PR TITLE
Add raw query

### DIFF
--- a/packages/osmosis-test-tube/src/runner/app.rs
+++ b/packages/osmosis-test-tube/src/runner/app.rs
@@ -132,6 +132,10 @@ impl<'a> Runner<'a> for OsmosisTestApp {
         self.inner.query(path, q)
     }
 
+    fn raw_query(&self, path: &str, value: Vec<u8>) -> RunnerResult<Vec<u8>> {
+        self.inner.raw_query(path, value)
+    }
+
     fn execute_multiple_raw<R>(
         &self,
         msgs: Vec<cosmrs::Any>,

--- a/packages/test-tube/src/runner/app.rs
+++ b/packages/test-tube/src/runner/app.rs
@@ -396,4 +396,17 @@ impl<'a> Runner<'a> for BaseApp {
                 .map_err(RunnerError::DecodeError)
         }
     }
+
+    fn raw_query(&self, path: &str, value: Vec<u8>) -> RunnerResult<Vec<u8>> {
+        let base64_query_msg_bytes = base64::encode(value);
+        redefine_as_go_string!(path);
+        redefine_as_go_string!(base64_query_msg_bytes);
+
+        unsafe {
+            let res = Query(self.id, path, base64_query_msg_bytes);
+            let res = RawResult::from_non_null_ptr(res).into_result()?;
+
+            Ok(res)
+        }
+    }
 }

--- a/packages/test-tube/src/runner/mod.rs
+++ b/packages/test-tube/src/runner/mod.rs
@@ -69,4 +69,6 @@ pub trait Runner<'a> {
     where
         Q: ::prost::Message,
         R: ::prost::Message + DeserializeOwned + Default;
+
+    fn raw_query(&self, path: &str, value: Vec<u8>) -> RunnerResult<Vec<u8>>;
 }


### PR DESCRIPTION
I want to bypass the `proto::Message` applied to request and response in current implementation.