### PR TITLE
add go mod tidy to build.rs

### DIFF
--- a/packages/osmosis-test-tube/build.rs
+++ b/packages/osmosis-test-tube/build.rs
@@ -98,6 +98,20 @@ fn build_libosmosistesttube(out: PathBuf) {
         return;
     }
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    let tidy_status = Command::new("go")
+        .current_dir(manifest_dir.join("libosmosistesttube"))
+        .arg("mod")
+        .arg("tidy")
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    if !tidy_status.success() {
+        panic!("failed to run 'go mod tidy'");
+    }
+
     let exit_status = Command::new("go")
         .current_dir(manifest_dir.join("libosmosistesttube"))
         .arg("build")


### PR DESCRIPTION
This PR aims to solve the following error during test_tube compiling process:

```
error: failed to run custom build command for `osmosis-test-tube v22.0.0`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_TEST_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/path/to/my/project/target/debug/build/osmosis-test-tube-dc1bce7c949200c4/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=./libosmosistesttube

  --- stderr
  go: updates to go.mod needed; to update it:
        go mod tidy
  thread 'main' panicked at 'failed to build go code', /path/to/my/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/osmosis-test-tube-22.0.0/build.rs:116:9
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:593:5
     1: core::panicking::panic_fmt
               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67:14
     2: build_script_build::build_libosmosistesttube
     3: build_script_build::main
     4: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
warning: build failed, waiting for other jobs to finish...
```