### PR TITLE
Use lossy string, instead of panicking on non-utf8

### DIFF
--- a/packages/test-tube/src/runner/result.rs
+++ b/packages/test-tube/src/runner/result.rs
@@ -216,11 +216,7 @@ impl RawResult {
         if code == 0 {
             Some(Self(Ok(content.to_vec())))
         } else {
-            let content_string = CString::new(content)
-                .unwrap()
-                .to_str()
-                .expect("Go code must encode valid UTF-8 string")
-                .to_string();
+            let content_string = CString::new(content).unwrap().to_string_lossy().to_string();
 
             let error = match code {
                 1 => RunnerError::QueryError {


### PR DESCRIPTION
Fixes #48 